### PR TITLE
Fix database setup

### DIFF
--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -10,7 +10,7 @@ jobs:
     runs-on: ubuntu-latest
     strategy:
       matrix:
-        python-version: ["3.6", "3.x"]
+        python-version: ["3.7", "3.x"]
 
     steps:
       - uses: actions/checkout@v2

--- a/email_account_validity/_store.py
+++ b/email_account_validity/_store.py
@@ -154,7 +154,26 @@ class EmailAccountValidityStore:
             DatabasePool.simple_insert_many_txn(
                 txn=txn,
                 table="email_account_validity",
-                values=list(users_to_insert.values()),
+                keys=[
+                    "user_id",
+                    "expiration_ts_ms",
+                    "email_sent",
+                    "long_renewal_token",
+                    "token_used_ts_ms",
+                ],
+                values=[
+                    (
+                        user["user_id"],
+                        user["expiration_ts_ms"],
+                        user["email_sent"],
+                        # If there's a renewal token for the user, we consider it's a long
+                        # one, because the non-module implementation of account validity
+                        # doesn't have a concept of short tokens.
+                        user["renewal_token"],
+                        user["token_used_ts_ms"],
+                    )
+                    for user in users_to_insert.values()
+                ],
             )
 
             return len(missing_users)

--- a/email_account_validity/_store.py
+++ b/email_account_validity/_store.py
@@ -48,25 +48,28 @@ class EmailAccountValidityStore:
         """
         def create_table_txn(txn: LoggingTransaction):
             # Try to create a table for the module.
+
+            # The table we create has the following columns:
+            #
+            # * user_id: The user's Matrix ID.
+            # * expiration_ts_ms: The expiration timestamp for this user in milliseconds.
+            # * email_sent: Whether a renewal email has already been sent to this user
+            # * long_renewal_token: Long renewal tokens, which are unique to the whole
+            #                       table, so that renewing an account using one doesn't
+            #                       require further authentication.
+            # * short_renewal_token: Short renewal tokens, which aren't unique to the
+            #                        whole table, and with which renewing an account
+            #                        requires authentication using an access token.
+            # * token_used_ts_ms: Timestamp at which the renewal token for the user has
+            #                     been used, or NULL if it hasn't been used yet.
             txn.execute(
                 """
                 CREATE TABLE IF NOT EXISTS email_account_validity(
-                    -- The user's Matrix ID.
                     user_id TEXT PRIMARY KEY,
-                    -- The expiration timestamp for this user in milliseconds.
                     expiration_ts_ms BIGINT NOT NULL,
-                    -- Whether a renewal email has already been sent to this user.
                     email_sent BOOLEAN NOT NULL,
-                    -- Long renewal tokens, which are unique to the whole table, so that
-                    -- renewing an account using one doesn't require further
-                    -- authentication.
                     long_renewal_token TEXT,
-                    -- Short renewal tokens, which aren't unique to the whole table, and
-                    -- with which renewing an account requires authentication using an
-                    -- access token.
                     short_renewal_token TEXT,
-                    -- Timestamp at which the renewal token for the user has been used,
-                    -- or NULL if it hasn't been used yet.
                     token_used_ts_ms BIGINT
                 )
                 """,

--- a/tests/__init__.py
+++ b/tests/__init__.py
@@ -22,7 +22,6 @@ import jinja2
 from synapse.module_api import ModuleApi
 
 from email_account_validity import EmailAccountValidity
-from email_account_validity._config import EmailAccountValidityConfig
 
 
 class SQLiteStore:

--- a/tests/test_account_validity.py
+++ b/tests/test_account_validity.py
@@ -14,7 +14,6 @@
 # limitations under the License.
 
 import asyncio
-import re
 import time
 
 # From Python 3.8 onwards, aiounittest.AsyncTestCase can be replaced by

--- a/tox.ini
+++ b/tox.ini
@@ -3,8 +3,7 @@ envlist = tests
 
 [testenv:tests]
 deps =
-    ;TODO: Change this dependency to matrix-synapse>=1.39.0 once it's out.
-    git+https://github.com/matrix-org/synapse.git@develop#egg=matrix-synapse
+    matrix-synapse>=1.39.0
     aiounittest>=1.4.0
 
 commands =


### PR DESCRIPTION
* Workaround the issue addressed by https://github.com/matrix-org/synapse/pull/13129 (so we don't have to wait a full release cycle to have the module work)
* Fix our use of `DatabasePool.simple_insert_many_txn` since it's changed now
* Use the right version of Synapse in CI

This issue went unnoticed because we use `run_as_background` to setup the database table (as it's the only way we can run async code in `__init__`). AFAIK that function is meant to call async coroutines in a "fire and forget" mode, meaning we don't do anything when one of these coroutines fail. This is problematic and probably best fixed by moving away from `run_as_background` for this kind of operations, and implementing something like https://github.com/matrix-org/synapse/issues/12433.